### PR TITLE
Add install target for qmodemhelper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(qmodemhelper)
 cmake_minimum_required(VERSION 3.22)
+project(qmodemhelper)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 find_program(CTAGS ctags)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,3 +36,4 @@ add_executable(qmodemhelper
 
 target_link_libraries(qmodemhelper udev ${LIBXML2_LIBRARIES}  ${MM-GLIB_LIBRARIES} ${MBIM-GLIB_LIBRARIES})
 
+install (TARGETS qmodemhelper RUNTIME DESTINATION bin)


### PR DESCRIPTION
Adds install target to allow it to build via portage, and addresses a cmake warning.