### PR TITLE
 `qmodemhelper --flash_mode_check` prints 'true' or 'false'

### DIFF
--- a/ql-modem-helper.c
+++ b/ql-modem-helper.c
@@ -328,9 +328,9 @@ int main(int argc, char *argv[])
                 break;
             case 'M':
 				if (flash_mode_check()) {
-					printf("\nModem is in flashing mode\n");
+					printf("true\n");
 				} else {
-					printf("\nModem is in normal operating mode\n");
+					printf("false\n");
 				}
                 return 0;
 			case 'N':


### PR DESCRIPTION
 reference: https://chromium.googlesource.com/chromiumos/platform2/+/refs/heads/main/modemfwd/README.md

------------------------------------
reboot chromebook while flashing firmware,  after chromeOS coming back modemfwd calls  `-- flash_mode_check` , only if the helper returns 'true', modemfwd does flashing again otherwise does nothing and the module remains in flash mode.

