### PR TITLE
The existence check was removed and the fopen flag was changed to tru…

### DIFF
--- a/ql-modem-helper.c
+++ b/ql-modem-helper.c
@@ -83,15 +83,8 @@ static int power_lock(const char* path, const char* filename)
 	strncat(full_file_path,"/",1);
 	strncat(full_file_path,filename, strlen(filename));
 
-
-    // Check if file exists
-    if (access(full_file_path, F_OK) == 0) {
-			syslog(0, "Lock file already exists \n");
-    	return EXIT_FAILURE;
-    }
-
-    syslog(0, "Creating lock file %s \n", full_file_path);
-	if ((lock_file = fopen(full_file_path,"a")) == NULL) {
+  syslog(0, "Creating lock file %s \n", full_file_path);
+	if ((lock_file = fopen(full_file_path,"w")) == NULL) {
 			return EXIT_FAILURE;
 	}
 


### PR DESCRIPTION
fopen argument mode was changed to :
 w      Truncate file to zero length or create text file for writing.  The stream is positioned at the beginning of the file.

The file existence check was removed also.

Tested on chromebook  in the following way:
1. Run:
 ./qmodemhelper --flash_fw carrier:/opt/google/modemfwd-firmware/em060/CARRIER/01.101,main:/opt/google/modemfwd-firmware/em060/MAIN/01.101 

2.  Intrerupt the flashing.
3.  Run :
./qmodemhelper --reboot --power_enable_gpio=497
4. Wait for reboot
 ./qmodemhelper --flash_fw carrier:/opt/google/modemfwd-firmware/em060/CARRIER/01.101,main:/opt/google/modemfwd-firmware/em060/MAIN/01.101 
