### PR TITLE
Changed the recovery files path from OEM/<version> to OEM

### DIFF
--- a/ql-qdl-sahara.c
+++ b/ql-qdl-sahara.c
@@ -104,7 +104,7 @@ int qdl_flash_all(char * main_file_path,char*  oem_file_path,char* carrier_file_
   }
   if (oem_file_path) {
     printf("oem: %s\n", oem_file_path);
-
+    dirname(oem_file_path);
     sprintf(full_programmer_path , "%s/%s", dirname(oem_file_path), "prog_nand_firehose_9x55.mbn" );
     printf("programmer path : %s\n", full_programmer_path);
     file_handle = fopen(full_programmer_path, "rb");


### PR DESCRIPTION
Changed the recovery files path according to this tree:

em060/
├── CARRIER
│   ├── 01.003
│   │   └── carrier.bin
│   └── 01.102
│       └── carrier.bin
├── MAIN
│   ├── 01.003
│   │   └── main.bin
│   └── 01.102
│       └── main.bin
└── OEM
    ├── 01.003
    │   └── oem.bin
    ├── prog_nand_firehose_9x55.mbn
    ├── rawprogram_nand_p2K_b128K_recovery.xml
    └── sbl1_recovery.mbn
