### PR TITLE
Added validation of the gpio chip and extraction of baseline on the fly

### DIFF
--- a/ql-gpio.h
+++ b/ql-gpio.h
@@ -17,5 +17,5 @@
 #ifndef QL_GPIO_H
 #define QL_GPIO_H
 #define MAX_FILE_NAME_LEN 1024
-int gpio_reboot_modem(int reset_line);
+int gpio_reboot_modem(char* gpio_chip,int reset_line);
 #endif


### PR DESCRIPTION
The chip needs autodetection now so it work like this:

qmodem helper gets called like this:

**qmodemhelper --reboot --power_enable_gpio=INTC1056:00,300**

The implementation works like this:
enumerating all the gpio chips.
    for each chip a verification is being do see if it is "INTC1050:00" 
     if yes  get chip_baseline value ( the one that changes at each reboot).

reset_line is 300
reset_line = reset_line + chip_baseline ( Ex:  300 + 512 = 812 )

proceed on reseting 812 as we did in the past. 