### PR TITLE
Configure heartbeat interval 120s for idle state

### DIFF
--- a/ql-modem-helper.c
+++ b/ql-modem-helper.c
@@ -69,6 +69,7 @@ const char kUnknownRevision[] = "unknown-revision";
 // Key used for heartbeat configuration;
 const char kHeartbeatMaxFailures[] = "max_failures";
 const char kHeartbeatInterval[] = "interval";
+const char kHeartbeatModemIdleInterval[] = "modem_idle_interval";
 
 static int print_help(int);
 static int parse_flash_fw_parameters(char *arg, char *main_fw, char *oem_fw, char *carrier_fw);
@@ -319,6 +320,7 @@ int main(int argc, char *argv[])
         case 'O':
           printf("%s:3\n", kHeartbeatMaxFailures);
           printf("%s:20\n", kHeartbeatInterval);
+          printf("%s:120\n", kHeartbeatModemIdleInterval);
           return 0;
         case 'H':
           print_help(argc);


### PR DESCRIPTION
To reduce power consumption due to heartbeat task, its interval is set to 120s when the modem is in idle state. In other states when modem is active, the default interval is 20s. 